### PR TITLE
Fixed jti/UUID matching for refreshToken (allows revocation)

### DIFF
--- a/function/controller/auth/main.go
+++ b/function/controller/auth/main.go
@@ -113,6 +113,13 @@ func validateRefreshToken(refreshToken string) *jwt.Token {
 	if claims["sub"] != "refresh" {
 		return nil
 	}
+
+	// Check jti for a match to UUID
+	if oAuth.RefreshUID != claims["jti"] {
+		log.Println("Invalid UUID for RefreshToken.")
+		return nil
+	}
+
 	if time.Unix(int64(claims["exp"].(float64)), 0).Before(time.Now()) {
 		return nil
 	}


### PR DESCRIPTION
Apparently I missed putting in the jti claim check on refresh tokens. Now that it's in revocation/logging out is as simple as changing the `refresh_uid` field in our oauth table.